### PR TITLE
Skip translation of requests type 'other' in order to fix a crash

### DIFF
--- a/umatrix2ublock.py
+++ b/umatrix2ublock.py
@@ -25,7 +25,7 @@ translate_request = {
 translate_action = {"allow": "noop", "inherit": "noop", "block": "block"}
 
 # Requests which cannot be translated
-skip_requests = ("cookie", "css", "plugin", "media")
+skip_requests = ("cookie", "css", "plugin", "media", "other")
 
 skip_rules = (
     "* * * block",


### PR DESCRIPTION
Previously the script would crash when it tried to translate a rule such as this:
`github.com * other inherit`
The crash prints this traceback:
```
Traceback (most recent call last):
  File "/home/XXXX/XXXXXX/builds/umatrix2ublock/umatrix2ublock.py", line 57, in <module>
    ub_request = translate_request[request].format(
KeyError: 'other'
```

I simply added 'other' requests to the list of request types to skip.